### PR TITLE
add DCUDA_GENERATION=Auto

### DIFF
--- a/zzopencv.sh
+++ b/zzopencv.sh
@@ -45,6 +45,7 @@ export PKG_CONFIG_PATH="$ROOTDIR"/lib/pkgconfig:$PKG_CONFIG_PATH
 cmake \
     -DBUILD_EXAMPLES=OFF \
     -DWITH_QT=OFF \
+    -DCUDA_GENERATION=Auto \    
     -DOpenGL_GL_PREFERENCE=GLVND \
     -DBUILD_opencv_hdf=OFF \
     -DBUILD_PERF_TESTS=OFF \


### PR DESCRIPTION
add `-DCUDA_GENERATION=Auto \`  for the cmake argument in the `zzopencv.sh` to make it more robust to any kind of CUDA environment.