### PR TITLE
bad whitespace after bash config

### DIFF
--- a/zzopencv.sh
+++ b/zzopencv.sh
@@ -45,7 +45,7 @@ export PKG_CONFIG_PATH="$ROOTDIR"/lib/pkgconfig:$PKG_CONFIG_PATH
 cmake \
     -DBUILD_EXAMPLES=OFF \
     -DWITH_QT=OFF \
-    -DCUDA_GENERATION=Auto \    
+    -DCUDA_GENERATION=Auto \
     -DOpenGL_GL_PREFERENCE=GLVND \
     -DBUILD_opencv_hdf=OFF \
     -DBUILD_PERF_TESTS=OFF \


### PR DESCRIPTION
In zzopencv.sh, there is whitespace after
`-DCUDA_GENERATION=Auto \`,
which will cause the error:
```
CMake Error: The source directory "/home/visual/app/src/opencv/build/ "
does not exist.
```
because the configs after this line will be ignored.